### PR TITLE
BugFix: Fix direct-load write failure when there are empty spark partitions.

### DIFF
--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/writer/DirectLoadWriter.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/writer/DirectLoadWriter.scala
@@ -61,6 +61,8 @@ class DirectLoadWriter(oceanBaseConfig: OceanBaseConfig) extends Serializable {
   }
 
   private def flush(buffer: ArrayBuffer[Row], directLoader: DirectLoader): Unit = {
+    if (buffer.isEmpty) return
+
     val bucket = new ObDirectLoadBucket()
     buffer.foreach(
       row => {

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OceanBaseMySQLConnectorITCase.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OceanBaseMySQLConnectorITCase.scala
@@ -138,6 +138,49 @@ class OceanBaseMySQLConnectorITCase extends OceanBaseMySQLTestBase {
   }
 
   @Test
+  def testDirectLoadWithEmptySparkPartition(): Unit = {
+    initialize("sql/mysql/products.sql")
+
+    val session = SparkSession.builder().master("local[*]").getOrCreate()
+
+    session.sql(s"""
+                   |CREATE TEMPORARY VIEW test_sink
+                   |USING oceanbase
+                   |OPTIONS(
+                   |  "url"= "$getJdbcUrlWithoutDB",
+                   |  "rpc-port" = "$getRpcPort",
+                   |  "schema-name"="$getSchemaName",
+                   |  "table-name"="products",
+                   |  "username"="$getUsername",
+                   |  "password"="$getPassword",
+                   |  "direct-load.enabled"=true,
+                   |  "direct-load.host"="$getHost",
+                   |  "direct-load.rpc-port"=$getRpcPort
+                   |);
+                   |""".stripMargin)
+
+    session
+      .sql("""
+             |INSERT INTO test_sink
+             |SELECT /*+ REPARTITION(3) */ 101, 'scooter', 'Small 2-wheel scooter', 3.14;
+             |""".stripMargin)
+      .repartition(3)
+
+    val expected: util.List[String] = util.Arrays.asList(
+      "101,scooter,Small 2-wheel scooter,3.1400000000"
+    )
+    session.stop()
+
+    waitingAndAssertTableCount("products", expected.size)
+
+    val actual: util.List[String] = queryTable("products")
+
+    assertEqualsInAnyOrder(expected, actual)
+
+    dropTables("products")
+  }
+
+  @Test
   def testDataFrameDirectLoadWrite(): Unit = {
     initialize("sql/mysql/products.sql")
 


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix direct-load write failure when there are empty spark partitions.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
