### PR TITLE
fix: support large number primary key in Oracle partition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ build/
 LocalTest.scala
 set-test-env.sh
 *.db
+
+### Claude Code ###
+claude.md

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBOraclePartition.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBOraclePartition.scala
@@ -23,6 +23,7 @@ import com.oceanbase.spark.utils.OBJdbcUtils
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.InputPartition
 
+import java.math.RoundingMode
 import java.sql.Connection
 import java.util.Objects
 
@@ -226,7 +227,10 @@ object OBOraclePartition extends Logging {
     }.toArray
   }
 
-  private case class IntPriKeyTableInfo(count: Long, min: Long, max: Long)
+  private case class IntPriKeyTableInfo(
+      count: Long,
+      min: java.math.BigDecimal,
+      max: java.math.BigDecimal)
 
   private def obtainIntPriKeyTableInfo(
       connection: Connection,
@@ -251,8 +255,15 @@ object OBOraclePartition extends Logging {
         .format(normalizePkNameForSql(priKeyColumnName), normalizePkNameForSql(priKeyColumnName))
     try {
       val rs = statement.executeQuery(sql)
-      if (rs.next()) IntPriKeyTableInfo(rs.getLong(1), rs.getLong(2), rs.getLong(3))
-      else throw new RuntimeException(s"Failed to obtain count of $tableName.")
+      if (rs.next()) {
+        val minBd = Option(rs.getBigDecimal(2))
+          .map(_.setScale(0, RoundingMode.FLOOR))
+          .getOrElse(java.math.BigDecimal.ZERO)
+        val maxBd = Option(rs.getBigDecimal(3))
+          .map(_.setScale(0, RoundingMode.CEILING))
+          .getOrElse(java.math.BigDecimal.ZERO)
+        IntPriKeyTableInfo(rs.getLong(1), minBd, maxBd)
+      } else throw new RuntimeException(s"Failed to obtain count of $tableName.")
     } finally {
       statement.close()
     }
@@ -269,15 +280,24 @@ object OBOraclePartition extends Logging {
       config.getJdbcMaxRecordsPrePartition.orElse(calPartitionSize(keyTableInfo.count))
     val numPartitions =
       Math.ceil(keyTableInfo.count.toDouble / desiredRowsPerPartition).toInt.max(1)
-    val idRange = keyTableInfo.max - keyTableInfo.min
-    val step = (idRange + numPartitions - 1) / numPartitions
+    val numPartBd = java.math.BigDecimal.valueOf(numPartitions.toLong)
+    val idRange = keyTableInfo.max.subtract(keyTableInfo.min)
+    val step = idRange
+      .add(numPartBd)
+      .subtract(java.math.BigDecimal.ONE)
+      .divide(numPartBd, 0, RoundingMode.FLOOR)
     val useHidden = priKeyColumnName.replace("\"", "") == HIDDEN_PK_INCREMENT
 
     (0 until numPartitions).map {
       i =>
-        val lower = keyTableInfo.min + i * step
-        val upper = if (i == numPartitions - 1) keyTableInfo.max + 1 else lower + step
-        val whereClause = s"($priKeyColumnName >= $lower AND $priKeyColumnName < $upper)"
+        val iBd = java.math.BigDecimal.valueOf(i.toLong)
+        val lower = keyTableInfo.min.add(step.multiply(iBd))
+        val upper =
+          if (i == numPartitions - 1) keyTableInfo.max.add(java.math.BigDecimal.ONE)
+          else lower.add(step)
+        val lowerStr = lower.toPlainString
+        val upperStr = upper.toPlainString
+        val whereClause = s"($priKeyColumnName >= $lowerStr AND $priKeyColumnName < $upperStr)"
         OBOraclePartition(
           partitionClause = partitionClause,
           limitOffsetClause = EMPTY_STRING,

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/writer/DirectLoadWriter.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/writer/DirectLoadWriter.scala
@@ -20,7 +20,7 @@ import com.oceanbase.spark.directload.{DirectLoader, DirectLoadUtils}
 
 import com.alipay.oceanbase.rpc.direct_load.ObDirectLoadBucket
 import com.alipay.oceanbase.rpc.protocol.payload.impl.ObObj
-import org.apache.commons.lang.StringUtils
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{DataFrame, Row}
 
 import java.util.Objects

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/resources/sql/oracle/products_simple.sql
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/resources/sql/oracle/products_simple.sql
@@ -60,4 +60,12 @@ CREATE TABLE products_full_unique_key (
     CONSTRAINT uk_products_full_unique UNIQUE (id, name, description, weight)
 );
 
+CREATE TABLE products_large_num_pk (
+    cust_id NUMBER(24,0) NOT NULL,
+    name VARCHAR2(255),
+    description VARCHAR2(1000),
+    weight NUMBER(10,2),
+    CONSTRAINT pk_products_large_num PRIMARY KEY (cust_id)
+);
+
 

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OBCatalogOracleITCase.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OBCatalogOracleITCase.scala
@@ -53,7 +53,8 @@ class OBCatalogOracleITCase extends OceanBaseOracleTestBase {
       "PRODUCTS_FULL_PRI_KEY",
       "PRODUCTS_NO_INT_PRI_KEY",
       "PRODUCTS_UNIQUE_KEY",
-      "PRODUCTS_FULL_UNIQUE_KEY"
+      "PRODUCTS_FULL_UNIQUE_KEY",
+      "PRODUCTS_LARGE_NUM_PK"
     )
   }
 
@@ -513,6 +514,50 @@ class OBCatalogOracleITCase extends OceanBaseOracleTestBase {
       "select NAME, min(ID), max(WEIGHT) from PRODUCTS group by NAME order by NAME desc limit 3",
       expect1)
 
+    session.stop()
+  }
+
+  @Test
+  def testReadLargeNumberPrimaryKey(): Unit = {
+    val session = SparkSession
+      .builder()
+      .master("local[*]")
+      .config("spark.sql.catalog.ob", OB_CATALOG_CLASS)
+      .config("spark.sql.catalog.ob.url", getJdbcUrl)
+      .config("spark.sql.catalog.ob.username", getUsername)
+      .config("spark.sql.catalog.ob.password", getPassword)
+      .config("spark.sql.catalog.ob.schema-name", getSchemaName)
+      .config("spark.sql.catalog.ob.jdbc.max-records-per-partition", 3)
+      .getOrCreate()
+
+    session.sql("use ob;")
+    session.sql(s"""
+                   |INSERT INTO $getSchemaName.PRODUCTS_LARGE_NUM_PK VALUES
+                   |(100000000000000000001, 'item_a', 'description_a', 1.00),
+                   |(100000000000000000002, 'item_b', 'description_b', 2.00),
+                   |(100000000000000000003, 'item_c', 'description_c', 3.00),
+                   |(100000000000000000004, 'item_d', 'description_d', 4.00),
+                   |(100000000000000000005, 'item_e', 'description_e', 5.00),
+                   |(100000000000000000006, 'item_f', 'description_f', 6.00),
+                   |(100000000000000000007, 'item_g', 'description_g', 7.00),
+                   |(100000000000000000008, 'item_h', 'description_h', 8.00),
+                   |(100000000000000000009, 'item_i', 'description_i', 9.00);
+                   |""".stripMargin)
+
+    import scala.collection.JavaConverters._
+    val expectedData: util.List[String] = Seq(
+      "100000000000000000001,item_a,description_a,1.00",
+      "100000000000000000002,item_b,description_b,2.00",
+      "100000000000000000003,item_c,description_c,3.00",
+      "100000000000000000004,item_d,description_d,4.00",
+      "100000000000000000005,item_e,description_e,5.00",
+      "100000000000000000006,item_f,description_f,6.00",
+      "100000000000000000007,item_g,description_g,7.00",
+      "100000000000000000008,item_h,description_h,8.00",
+      "100000000000000000009,item_i,description_i,9.00"
+    ).toList.asJava
+
+    queryAndVerifyTableData(session, "PRODUCTS_LARGE_NUM_PK", expectedData)
     session.stop()
   }
 


### PR DESCRIPTION
## Summary
- Use BigDecimal instead of Long for primary key range calculation to handle NUMBER(24,0) type which exceeds Long.MAX_VALUE
- Fix StringUtils import from commons-lang to commons-lang3
- Add test case for large number primary key reading

## Test plan
- [x] Added `testReadLargeNumberPrimaryKey` test case with NUMBER(24,0) primary key values