### PR TITLE
fix `listTables` has error in Oracle mode

### DIFF
--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/catalog/OceanBaseCatalog.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/catalog/OceanBaseCatalog.scala
@@ -72,7 +72,7 @@ class OceanBaseCatalog
       conn =>
         val schemaPattern = if (namespace.length == 1) namespace.head else null
         val rs = conn.getMetaData
-          .getTables(schemaPattern, "%", "%", Array("TABLE"));
+          .getTables(schemaPattern, schemaPattern, "%", Array("TABLE"));
         new Iterator[Identifier] {
           def hasNext: Boolean = rs.next()
           def next(): Identifier = Identifier.of(namespace, rs.getString("TABLE_NAME"))


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
When executing `listTables` in Oracle mode, all tables that the current user has permission to access will be retrieved.

Because in the Oracle mode, obtaining table metadata is achieved through `schemaPattern` rather than `catalog`, hardcoding `schemaPattern` as '%' in the code results in retrieving tables from all schemas.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Change the hard-coded '%' to use `schemaPattern`.