### PR TITLE
fix: quote reserved-word partition column specified via runtime conf

### DIFF
--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBMySQLPartition.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBMySQLPartition.scala
@@ -71,8 +71,17 @@ object OBMySQLPartition extends Logging {
             val partColConfig = String.format(
               OceanBaseConfig.SPECIFY_PK_TABLE_PARTITION_COLUMN.getKey,
               dialect.unQuoteIdentifier(config.getDbTable))
-            configPartitionColumn = Optional.ofNullable(
-              configPartitionColumn.orElse(ConfigUtils.findFromRuntimeConf(partColConfig)))
+            // Quote the column name from runtime conf, keeping it consistent with the other
+            // partition-column sources (getJdbcReaderPartitionColumn and getPriKeyInfo already
+            // return quoted names). Otherwise a reserved-word column (e.g. `usage`) would break
+            // the generated partition/stats SQL.
+            val runtimeConfPartitionColumn = ConfigUtils.findFromRuntimeConf(partColConfig)
+            val quotedRuntimeConfPartitionColumn =
+              if (runtimeConfPartitionColumn != null)
+                dialect.quoteIdentifier(runtimeConfPartitionColumn)
+              else null
+            configPartitionColumn =
+              Optional.ofNullable(configPartitionColumn.orElse(quotedRuntimeConfPartitionColumn))
             if (config.getDisableIntPkTableUseWherePartition) {
               limitOffsetPartitionWay(connection, config, obPartInfos)
             } else if (null == finalIntPriKey) {

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/resources/sql/mysql/products.sql
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/resources/sql/mysql/products.sql
@@ -48,6 +48,16 @@ CREATE TABLE products_no_int_pri_key
   primary key(id, name)
 );
 
+-- Table for testing a reserved-word column (`usage`) used as the read partition column.
+CREATE TABLE products_reserved_word_pri_key
+(
+  id          VARCHAR(255) NOT NULL ,
+  `usage`     VARCHAR(255) NOT NULL,
+  description VARCHAR(512),
+  weight      DECIMAL(20, 10),
+  primary key(id, `usage`)
+);
+
 CREATE TABLE products_unique_key
 (
   id          INTEGER ,

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OBCatalogMySQLITCase.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/OBCatalogMySQLITCase.scala
@@ -40,6 +40,7 @@ class OBCatalogMySQLITCase extends OceanBaseMySQLTestBase {
       "products_no_pri_key",
       "products_full_pri_key",
       "products_no_int_pri_key",
+      "products_reserved_word_pri_key",
       "products_unique_key",
       "products_full_unique_key",
       "products_pri_and_unique_key",
@@ -563,6 +564,38 @@ class OBCatalogMySQLITCase extends OceanBaseMySQLTestBase {
     session.sql("use ob;")
     insertTestData(session, "products_no_int_pri_key")
     queryAndVerifyTableData(session, "products_no_int_pri_key", expected)
+
+    session.stop()
+  }
+
+  /**
+   * Regression test: when the read partition column is specified via a bare Spark runtime conf
+   * (i.e. not as a `spark.sql.catalog.<name>.*` option, so it is resolved through
+   * `ConfigUtils.findFromRuntimeConf` rather than `getJdbcReaderPartitionColumn`) and the column
+   * name is a reserved word (e.g. `usage`), the generated partition/stats SQL must still quote it.
+   */
+  @Test
+  def testUnevenlyReadWithReservedWordPartitionColumn(): Unit = {
+    val session = SparkSession
+      .builder()
+      .master("local[*]")
+      .config("spark.sql.catalog.ob", OB_CATALOG_CLASS)
+      .config("spark.sql.catalog.ob.url", getJdbcUrl)
+      .config("spark.sql.catalog.ob.username", getUsername)
+      .config("spark.sql.catalog.ob.password", getPassword)
+      .config("spark.sql.catalog.ob.jdbc.max-records-per-partition", "2")
+      .config("spark.sql.catalog.ob.schema-name", getSchemaName)
+      .getOrCreate()
+
+    // Set the partition column as a bare runtime conf (no catalog prefix) so it is only picked up
+    // by ConfigUtils.findFromRuntimeConf, exercising the branch that previously left the reserved
+    // word unquoted.
+    session.conf
+      .set(s"jdbc.$getSchemaName.products_reserved_word_pri_key.partition-column", "usage")
+
+    session.sql("use ob;")
+    insertTestData(session, "products_reserved_word_pri_key")
+    queryAndVerifyTableData(session, "products_reserved_word_pri_key", expected)
 
     session.stop()
   }


### PR DESCRIPTION
## What

When the read partition column is specified through a **bare Spark runtime conf** (not a `spark.sql.catalog.<name>.*` option) and the column name happens to be a reserved word (e.g. `usage`), the generated partition/stats SQL leaves the identifier unquoted, producing a SQL syntax error.

## Why

In `OBMySQLPartition.columnPartition`, the partition column can come from three sources:

| Source | Quoted? |
|---|---|
| `config.getJdbcReaderPartitionColumn(dialect)` (catalog option) | ✅ via `dialect.quoteIdentifier` |
| `priKeyColInfos.head.columnName` (from `getPriKeyInfo`) | ✅ already quoted |
| `ConfigUtils.findFromRuntimeConf(...)` (bare runtime conf) | ❌ **raw value** |

Only the runtime-conf source returned the raw column name. That value then flows into the generated `WHERE` / `min()`/`max()` / `ORDER BY` chunk queries, so a reserved-word column breaks them:

```
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; ...
near '), max(usage)
      FROM `test`.`products_reserved_word_pri_key`' at line 2
```

## How

Quote the runtime-conf column name at the source with `dialect.quoteIdentifier`, so all three partition-column sources are consistently pre-quoted and no downstream SQL construction needs to change.

## Tests

- Added `OBCatalogMySQLITCase#testUnevenlyReadWithReservedWordPartitionColumn`, which sets the partition column as a bare runtime conf (`jdbc.<schema>.<table>.partition-column = usage`) against a new table `products_reserved_word_pri_key` whose PK contains the reserved word `usage`.
- Verified the test **fails without the fix** (the `SQLSyntaxErrorException` above) and **passes with it**.
- Existing `testUnevenlyRead` still passes; spotless check passes.

<details>
<summary>Failing output before the fix</summary>

```
Output: id#12, usage#13, description#14, weight#15
Test ...testUnevenlyReadWithReservedWordPartitionColumn failed with:
java.sql.SQLSyntaxErrorException: You have an error in your SQL syntax; check the manual
that corresponds to your OceanBase version for the right syntax to use near '), max(usage)
              FROM `test`.`products_reserved_word_pri_key`' at line 2
```
</details>
