### PR TITLE
Fix: Quote reserved-word columns in catalog JDBC read SQL

### DIFF
--- a/spark-connector-oceanbase/spark-connector-oceanbase-3.1/src/main/scala/com/oceanbase/spark/reader/v2/OBJdbcReader.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-3.1/src/main/scala/com/oceanbase/spark/reader/v2/OBJdbcReader.scala
@@ -95,7 +95,7 @@ class OBJdbcReader(
 
   private def buildQuerySql(): String = {
     val columns = schema.map(col => dialect.quoteIdentifier(col.name)).toArray
-    val columnStr: String = if (columns.isEmpty) "1" else columns.mkString(",")
+    val columnStr: String = if (columns.isEmpty) "1" else columns.mkString(", ")
 
     val filterWhereClause: String =
       pushedFilter

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseDialect.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseDialect.scala
@@ -162,7 +162,7 @@ abstract class OceanBaseDialect extends Logging with Serializable {
    * is a reserved keyword, or in case it contains characters that require quotes (e.g. space).
    */
   def quoteIdentifier(colName: String): String = {
-    s"""`$colName`"""
+    s"`${colName.replace("`", "``")}`"
   }
 
   def unQuoteIdentifier(colName: String): String = {

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseMySQLDialect.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseMySQLDialect.scala
@@ -202,7 +202,7 @@ class OceanBaseMySQLDialect extends OceanBaseDialect {
             val columnKey = rs.getString(3)
             if (null != columnKey && columnKey.equals("PRI")) {
               arrayBuffer += PriKeyColumnInfo(
-                quoteIdentifier(rs.getString(1)),
+                rs.getString(1),
                 rs.getString(2),
                 columnKey,
                 rs.getString(4),

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseOracleDialect.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/dialect/OceanBaseOracleDialect.scala
@@ -37,7 +37,7 @@ import scala.util.control.NonFatal
 
 class OceanBaseOracleDialect extends OceanBaseDialect {
   override def quoteIdentifier(colName: String): String = {
-    s""""$colName""""
+    s""""${colName.replace("\"", "\"\"")}""""
   }
 
   override def unQuoteIdentifier(colName: String): String = {

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBJdbcReader.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBJdbcReader.scala
@@ -126,8 +126,8 @@ class OBJdbcReader(
                 case _ => quoted
               }
           }
-          if (projected.isEmpty) "1" else projected.mkString(",")
-        case _ => if (columns.isEmpty) "1" else columns.mkString(",")
+          if (projected.isEmpty) "1" else projected.mkString(", ")
+        case _ => if (columns.isEmpty) "1" else columns.mkString(", ")
       }
     }
 
@@ -216,10 +216,13 @@ class OBJdbcReader(
       case _ => ""
     }
 
-    s"""
-       |SELECT $hint $columnStr FROM ${config.getDbTable} $partitionClause
-       |$whereClause $getGroupByClause $getOrderByClause $finalLimitClause
-       |""".stripMargin
+    val sql =
+      s"""
+         |SELECT $hint $columnStr FROM ${config.getDbTable} $partitionClause
+         |$whereClause $getGroupByClause $getOrderByClause $finalLimitClause
+         |""".stripMargin
+    logDebug(s"OceanBase JDBC read SQL: $sql")
+    sql
   }
 
   /**

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBMySQLPartition.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/main/scala/com/oceanbase/spark/reader/v2/OBMySQLPartition.scala
@@ -84,7 +84,8 @@ object OBMySQLPartition extends Logging {
                 connection,
                 config,
                 EMPTY_STRING,
-                finalIntPriKey.columnName)
+                finalIntPriKey.columnName,
+                dialect)
               val priKeyDepth = info.max - info.min
               // Check the uniformity of the integer primary key value distribution. TODO：Refine logic of Check the uniformity
               if ((priKeyDepth >= info.count * 2) || (priKeyDepth * 2 <= info.count)) {
@@ -97,12 +98,18 @@ object OBMySQLPartition extends Logging {
                 whereEvenlySizedPartitionWay(
                   connection,
                   config,
+                  dialect,
                   obPartInfos,
                   finalIntPriKey.columnName)
               }
             }
           } else { // non-primary key table
-            whereEvenlySizedPartitionWay(connection, config, obPartInfos, HIDDEN_PK_INCREMENT)
+            whereEvenlySizedPartitionWay(
+              connection,
+              config,
+              dialect,
+              obPartInfos,
+              HIDDEN_PK_INCREMENT)
           }
         }
     }
@@ -124,14 +131,15 @@ object OBMySQLPartition extends Logging {
   private def whereEvenlySizedPartitionWay(
       connection: Connection,
       config: OceanBaseConfig,
+      dialect: OceanBaseDialect,
       obPartInfos: Array[OBPartInfo],
       priKeyColumnName: String) = {
     if (obPartInfos.length == 1 && Objects.isNull(obPartInfos(0).partName)) {
       // For non-partition table
-      computeWherePartInfoForNonPartTable(connection, config, priKeyColumnName)
+      computeWherePartInfoForNonPartTable(connection, config, dialect, priKeyColumnName)
     } else {
       // For partition table
-      computeWherePartInfoForPartTable(connection, config, obPartInfos, priKeyColumnName)
+      computeWherePartInfoForPartTable(connection, config, dialect, obPartInfos, priKeyColumnName)
     }
   }
 
@@ -291,6 +299,7 @@ object OBMySQLPartition extends Logging {
   private def computeWherePartInfoForPartTable(
       connection: Connection,
       config: OceanBaseConfig,
+      dialect: OceanBaseDialect,
       obPartInfos: Array[OBPartInfo],
       priKeyColumnName: String): Array[InputPartition] = {
     val arr = new ArrayBuffer[OBMySQLPartition]()
@@ -301,9 +310,9 @@ object OBMySQLPartition extends Logging {
           case _ => PARTITION_QUERY_FORMAT.format(obPartInfo.subPartName)
         }
         val keyTableInfo =
-          obtainIntPriKeyTableInfo(connection, config, partitionName, priKeyColumnName)
+          obtainIntPriKeyTableInfo(connection, config, partitionName, priKeyColumnName, dialect)
         val partitions =
-          computeWhereSparkPart(keyTableInfo, partitionName, priKeyColumnName, config)
+          computeWhereSparkPart(keyTableInfo, partitionName, priKeyColumnName, config, dialect)
         arr ++= partitions
       })
     arr.zipWithIndex.map {
@@ -333,7 +342,8 @@ object OBMySQLPartition extends Logging {
       keyTableInfo: IntPriKeyTableInfo,
       partitionClause: String,
       priKeyColumnName: String,
-      config: OceanBaseConfig): Array[OBMySQLPartition] = {
+      config: OceanBaseConfig,
+      dialect: OceanBaseDialect): Array[OBMySQLPartition] = {
     // Return empty array if table has no rows
     if (keyTableInfo.count <= 0) {
       return Array.empty[OBMySQLPartition]
@@ -352,13 +362,14 @@ object OBMySQLPartition extends Logging {
     var useHiddenPKColumn = false
     if (priKeyColumnName.equals(HIDDEN_PK_INCREMENT))
       useHiddenPKColumn = true
+    val quotedPriKey = dialect.quoteIdentifier(priKeyColumnName)
     (0 until numPartitions).map {
       i =>
         val lower = keyTableInfo.min + i * step
         val upper =
           if (i == numPartitions - 1) keyTableInfo.max + 1
           else lower + step // Ensure upper bound includes max value for last partition
-        val whereClause = s"($priKeyColumnName >= $lower AND $priKeyColumnName < $upper)"
+        val whereClause = s"($quotedPriKey >= $lower AND $quotedPriKey < $upper)"
         OBMySQLPartition(
           partitionClause = partitionClause,
           limitOffsetClause = EMPTY_STRING,
@@ -371,11 +382,12 @@ object OBMySQLPartition extends Logging {
   private def computeWherePartInfoForNonPartTable(
       connection: Connection,
       config: OceanBaseConfig,
+      dialect: OceanBaseDialect,
       priKeyColumnName: String): Array[InputPartition] = {
     val priKeyColumnInfo =
-      obtainIntPriKeyTableInfo(connection, config, EMPTY_STRING, priKeyColumnName)
+      obtainIntPriKeyTableInfo(connection, config, EMPTY_STRING, priKeyColumnName, dialect)
     if (priKeyColumnInfo.count <= 0) Array.empty
-    computeWhereSparkPart(priKeyColumnInfo, EMPTY_STRING, priKeyColumnName, config)
+    computeWhereSparkPart(priKeyColumnInfo, EMPTY_STRING, priKeyColumnName, config, dialect)
       .asInstanceOf[Array[InputPartition]]
   }
 
@@ -383,7 +395,8 @@ object OBMySQLPartition extends Logging {
       connection: Connection,
       config: OceanBaseConfig,
       partName: String,
-      priKeyColumnName: String) = {
+      priKeyColumnName: String,
+      dialect: OceanBaseDialect) = {
     val statement = connection.createStatement()
     val tableName = config.getDbTable
     val useHiddenPKColHint =
@@ -392,11 +405,12 @@ object OBMySQLPartition extends Logging {
       else EMPTY_STRING
     val hint =
       s"/*+ PARALLEL(${config.getJdbcStatsParallelHintDegree}) $useHiddenPKColHint ${queryTimeoutHint(config)} */"
+    val quotedPriKey = dialect.quoteIdentifier(priKeyColumnName)
 
     val sql =
       s"""
               SELECT $hint
-                count(1) AS cnt, min($priKeyColumnName), max($priKeyColumnName)
+                count(1) AS cnt, min($quotedPriKey), max($quotedPriKey)
               FROM $tableName $partName
              """
     try {

--- a/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/dialect/OceanBaseDialectTest.scala
+++ b/spark-connector-oceanbase/spark-connector-oceanbase-base/src/test/scala/com/oceanbase/spark/dialect/OceanBaseDialectTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 OceanBase.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.oceanbase.spark.dialect
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class OceanBaseDialectTest {
+
+  private val mysqlDialect = new OceanBaseMySQLDialect
+  private val oracleDialect = new OceanBaseOracleDialect
+
+  @Test
+  def testMySQLQuoteIdentifierForReservedWords(): Unit = {
+    Seq("usage", "order", "group", "key", "rank", "index").foreach {
+      colName => assertEquals(s"`$colName`", mysqlDialect.quoteIdentifier(colName))
+    }
+  }
+
+  @Test
+  def testMySQLQuoteIdentifierEscapesEmbeddedBackticks(): Unit = {
+    assertEquals("`a``b`", mysqlDialect.quoteIdentifier("a`b"))
+  }
+
+  @Test
+  def testOracleQuoteIdentifierForReservedWords(): Unit = {
+    assertEquals("\"usage\"", oracleDialect.quoteIdentifier("usage"))
+  }
+
+  @Test
+  def testOracleQuoteIdentifierEscapesEmbeddedDoubleQuotes(): Unit = {
+    assertEquals("\"a\"\"b\"", oracleDialect.quoteIdentifier("a\"b"))
+  }
+}


### PR DESCRIPTION
Store raw primary key column names and apply dialect quoting when building partition predicates, so tables with columns like usage can be read via Spark catalog.

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
close #114 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
